### PR TITLE
Add points upon clicking on canvas

### DIFF
--- a/src/equations/canvas.cljs
+++ b/src/equations/canvas.cljs
@@ -103,7 +103,6 @@
                      (goog.object/get rect "top")
                      (:center-y graph))
                    (:scale-y graph))]
-    (js/console.log (:scale-y graph))
     (rf/dispatch
       [:click [x-coord y-coord]])))
 

--- a/src/equations/canvas.cljs
+++ b/src/equations/canvas.cljs
@@ -68,16 +68,34 @@
 
     ctx))
 
+;; Goal: write a helper function that takes the point where a user clicked on
+;; the canvas (in terms of pixel values) and return the associated data values.
+(defn coords-to-values
+  [coords config]
+  "Takes a vector with two elements: an x pixel value and y pixel value, and a
+  config object.  Returns a vector with an x _value_ and a y _value_, given the
+  mapping in the config.")
+
 ;; events
 
 (rf/reg-event-db
   :initialize
   (fn [_ _]
     {:equations []
-     :animate false}))
+     :animate false
+     ;; Goal: store x and y values in state
+     :points []}))
 
 (defn re-trigger-timer []
   (r/next-tick (fn [] (rf/dispatch [:timer]))))
+
+;; Goal: dispatch the :click event when a user clicks and capture the
+;; coordinates of their click
+(defn canvas-click []
+  (let [x-coord (...)
+        y-coord (...)]
+    (rf/dispatch [:click [x-coord y-coord]])))
+
 
 (rf/reg-event-db
   :timer
@@ -94,6 +112,12 @@
  :new-eq
  (fn [db [_ eq]]
    (update-in db [:equations] conj {:equation eq :opacity 100})))
+
+;; Goal: convert x and y coords into values (pixels->data), and store in db
+(rf/reg-event-db
+  :click
+  (fn [db [x-coord y-coord]]
+    (update-in db [:points] conj (coords-to-values x-coord y-coord))))
 
 (rf/reg-event-fx
  :toggle-animation
@@ -115,6 +139,11 @@
  :animate
  (fn [db _]
    (:animate db)))
+
+(rf/reg-sub
+  :points
+  (fn [db _]
+    (:points db)))
 
 ;; views
 
@@ -175,7 +204,8 @@
        :display-name "plot-inner"})))
 
 (defn plot-outer []
-  (let [equations (rf/subscribe [:equations])]
+  (let [equations (rf/subscribe [:equations])
+        points (rf/subscribe [:points])]
     (fn []
       [plot-inner {:equations @equations}])))
 


### PR DESCRIPTION
# What does this PR do?

This PR adds points to the canvas when a user clicks _and_ stores the `x` and `y` values of each point in state.

Notably, the `x` and `y` values are in our app's units (with `x=0`, `y=0` as the middle of the `canvas` element,) rather than - say - units of pixels starting from the top left-hand corner (which some online resources assume you're using.)

# How do I test this PR?

- Start the ClojureScript server, perhaps with `clj --main cljs.main --compile equations.canvas --repl`
- When you see buttons loaded in a browser tab, try clicking below them and confirm that you can see red dots